### PR TITLE
Switched to serde derive feature instead of serde_derive dependency.

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,6 +17,5 @@ travis-ci = { repository = "arcnmx/qapi-rs" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-serde = "^1.0.27"
-serde_derive = "^1.0.27"
+serde = { version = "^1.0.27", features = [ "derive" ] }
 serde_json = "^1.0.9"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -3,9 +3,9 @@
 pub mod spec {
     use std::collections::HashMap;
     use std::fmt;
-    use serde::de::{Deserializer, Deserialize, Visitor, SeqAccess, MapAccess, Error};
+    use serde::de::{Deserializer, Visitor, SeqAccess, MapAccess, Error};
     use serde::de::value::MapAccessDeserializer;
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
 
     #[derive(Debug, Clone, Deserialize)]
     #[serde(untagged, rename_all = "lowercase")]

--- a/qga/Cargo.toml
+++ b/qga/Cargo.toml
@@ -21,6 +21,5 @@ maintenance = { status = "passively-maintained" }
 qapi-codegen = { version = "^0.4.0", path = "../codegen" }
 
 [dependencies]
-serde = "^1.0.78"
-serde_derive = "^1.0.78"
+serde = { version = "^1.0.27", features = [ "derive" ] }
 qapi-spec = { version = "^0.2.0", path = "../spec" }

--- a/qga/src/lib.rs
+++ b/qga/src/lib.rs
@@ -4,7 +4,7 @@
 include!(concat!(env!("OUT_DIR"), "/qga.rs"));
 
 use std::{io, str, fmt, error};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]

--- a/qmp/Cargo.toml
+++ b/qmp/Cargo.toml
@@ -21,6 +21,5 @@ maintenance = { status = "passively-maintained" }
 qapi-codegen = { version = "^0.4.0", path = "../codegen" }
 
 [dependencies]
-serde = "^1.0.78"
-serde_derive = "^1.0.78"
+serde = { version = "^1.0.27", features = [ "derive" ] }
 qapi-spec = { version = "^0.2.0", path = "../spec" }

--- a/qmp/src/lib.rs
+++ b/qmp/src/lib.rs
@@ -2,7 +2,7 @@
 #![doc(html_root_url = "http://docs.rs/qapi-qmp/0.5.0")]
 
 use std::string;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 include!(concat!(env!("OUT_DIR"), "/qmp.rs"));
 

--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "arcnmx/qapi-rs" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-serde = "^1.0.27"
-serde_derive = "^1.0.27"
+serde = { version = "^1.0.27", features = [ "derive" ] }
 serde_json = "^1.0.9"
 base64 = "^0.10.0"

--- a/spec/src/lib.rs
+++ b/spec/src/lib.rs
@@ -1,9 +1,8 @@
 #![doc(html_root_url = "http://docs.rs/qapi-spec/0.2.2")]
 
 use std::{io, error, fmt};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde::de::DeserializeOwned;
-use serde_derive::{Deserialize, Serialize};
 
 pub use serde_json::Value as Any;
 pub type Dictionary = serde_json::Map<String, Any>;
@@ -65,7 +64,6 @@ pub mod base64_opt {
 }
 
 mod error_serde {
-    use serde_derive::{Serialize, Deserialize};
     use serde::{Serialize, Serializer, Deserialize, Deserializer};
     use crate::{Error, ErrorClass, Any};
 
@@ -210,7 +208,6 @@ pub struct Timestamp {
 }
 
 mod serde_command {
-    use serde_derive::Serialize;
     use serde::{Serialize, Serializer};
     use crate::{Command, Any};
 


### PR DESCRIPTION
Needed to fix compilation issue encountered when qapi was used together
with another crate that activated serde's derive feature. Followed the
recommendation here: https://github.com/serde-rs/serde/issues/1441