### PR TITLE
Respect manifest dir set during build script execution

### DIFF
--- a/qga/build.rs
+++ b/qga/build.rs
@@ -13,7 +13,9 @@ fn main_result() -> io::Result<()> {
     println!("rerun-if-changed=build.rs");
 
     let out_dir = path::Path::new(&env::var("OUT_DIR").unwrap()).join("qga.rs");
-    let schema_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/schema/qga/");
+    let schema_dir = path::Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap())
+        .join("schema")
+        .join("qga");
 
     for inc in qapi_codegen::codegen(schema_dir, out_dir, "QgaCommand".into())? {
         println!("rerun-if-changed={}", inc.display());

--- a/qmp/build.rs
+++ b/qmp/build.rs
@@ -13,7 +13,9 @@ fn main_result() -> io::Result<()> {
     println!("rerun-if-changed=build.rs");
 
     let out_dir = path::Path::new(&env::var("OUT_DIR").unwrap()).join("qmp.rs");
-    let schema_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/schema/qapi/");
+    let schema_dir = path::Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap())
+        .join("schema")
+        .join("qapi");
 
     for inc in qapi_codegen::codegen(schema_dir, out_dir, "QmpCommand".into())? {
         println!("rerun-if-changed={}", inc.display());


### PR DESCRIPTION
It is not correct to assume that the manifest directory when the build script is compiled (`env!("CARGO_MANIFEST_DIR")`) is the same as the manifest directory set by Cargo when the build script is executed (`env::var_os("CARGO_MANIFEST_DIR")`). In distributed builds these may even be on totally different machines.

Cargo's API for build scripts is that they are supposed to use the runtime value of these environment variables, for the above reason.

Using the build-time value leads to errors that look like:

```console
thread 'main' panicked at 'Os { code: 2, kind: NotFound, message: "No such file or directory" }', qapi-qmp-0.12.0/build.rs:8:19
```

because the directory used during compilation of the build script no longer exists, or is on some other machine.