### PR TITLE
parser: Support fdset feature

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -97,6 +97,7 @@ pub mod spec {
         AllowWriteOnlyOverlay,
         DynamicAutoReadOnly,
         SavevmMonitorNodes,
+        Fdset,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]


### PR DESCRIPTION
Looks like this is a new feature in v8.1.0. This is needed for https://github.com/arcnmx/qemu-qapi-filtered/pull/4 .