### PR TITLE
codegen: improve error reporting for missing QAPI schema includes

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -632,9 +632,15 @@ fn include<W: Write>(context: &mut Context<W>, repo: &mut QemuFileRepo, path: &s
     if context.included.contains(&include_path) {
         return Ok(())
     }
-    context.included.insert(include_path);
+    context.included.insert(include_path.clone());
 
-    let (mut repo, str) = repo.include(path)?;
+    let (mut repo, str) = match repo.include(path) {
+        Ok(val) => val,
+        Err(e) => {
+            let msg = format!("Failed to include file: {}\nError: {:?}", include_path.display(), e);
+            return Err(io::Error::new(e.kind(), msg));
+        }
+    };
     for item in Parser::from_string(Parser::strip_comments(&str)) {
         context.process(item?)?;
     }

--- a/qmp/schema/qapi/machine-target.json
+++ b/qmp/schema/qapi/machine-target.json
@@ -1,1 +1,0 @@
-../../../schema/qapi/machine-target.json

--- a/qmp/schema/qapi/misc-target.json
+++ b/qmp/schema/qapi/misc-target.json
@@ -1,1 +1,0 @@
-../../../schema/qapi/misc-target.json


### PR DESCRIPTION
* Wrap missing file errors in the `include` function with the file path and error details.
* Makes it easier to identify which schema file is missing or inaccessible during code generation.