### PR TITLE
qemu 11.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "schema"]
 	path = schema
 	url = https://github.com/arcnmx/qemu-qapi-filtered.git
+	branch = v11.0.1-filtered

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -632,9 +632,15 @@ fn include<W: Write>(context: &mut Context<W>, repo: &mut QemuFileRepo, path: &s
     if context.included.contains(&include_path) {
         return Ok(())
     }
-    context.included.insert(include_path);
+    context.included.insert(include_path.clone());
 
-    let (mut repo, str) = repo.include(path)?;
+    let (mut repo, str) = match repo.include(path) {
+        Ok(val) => val,
+        Err(e) => {
+            let msg = format!("Failed to include file: {}\nError: {:?}", include_path.display(), e);
+            return Err(io::Error::new(e.kind(), msg));
+        }
+    };
     for item in Parser::from_string(Parser::strip_comments(&str)) {
         context.process(item?)?;
     }

--- a/flake.lock
+++ b/flake.lock
@@ -95,17 +95,17 @@
     "schema": {
       "flake": false,
       "locked": {
-        "lastModified": 1753206370,
-        "narHash": "sha256-ZUezhnA6/yYDUxZkCy651rCQJ8j4+msQgLXOVu7wB7Y=",
+        "lastModified": 1779729206,
+        "narHash": "sha256-EaBKLvq8oZRnoDGO+AJTDrIaSGoOvN/m+ZH7vyDfxcI=",
         "owner": "arcnmx",
         "repo": "qemu-qapi-filtered",
-        "rev": "e7805e8c7ba1e0c6da1b3cce48a12eea122a8e61",
+        "rev": "ae9b8869ead8523846fd61f7832992159a09bef4",
         "type": "github"
       },
       "original": {
         "owner": "arcnmx",
-        "ref": "v10.0.3",
         "repo": "qemu-qapi-filtered",
+        "rev": "ae9b8869ead8523846fd61f7832992159a09bef4",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       type = "github";
       owner = "arcnmx";
       repo = "qemu-qapi-filtered";
-      ref = "v10.0.3"; # keep in sync with schema submodule
+      rev = "ae9b8869ead8523846fd61f7832992159a09bef4"; # v11.0.1-filtered; keep in sync with schema submodule
     };
     rust = {
       url = "github:arcnmx/nixexprs-rust";

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -98,6 +98,7 @@ pub mod spec {
         DynamicAutoReadOnly,
         SavevmMonitorNodes,
         Fdset,
+        ConfidentialGuestReset,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]

--- a/qmp/schema/qapi/accelerator.json
+++ b/qmp/schema/qapi/accelerator.json
@@ -1,0 +1,1 @@
+../../../schema/qapi/accelerator.json

--- a/qmp/schema/qapi/acpi-hest.json
+++ b/qmp/schema/qapi/acpi-hest.json
@@ -1,0 +1,1 @@
+../../../schema/qapi/acpi-hest.json

--- a/qmp/schema/qapi/machine-s390x.json
+++ b/qmp/schema/qapi/machine-s390x.json
@@ -1,0 +1,1 @@
+../../../schema/qapi/machine-s390x.json

--- a/qmp/schema/qapi/machine-target.json
+++ b/qmp/schema/qapi/machine-target.json
@@ -1,1 +1,0 @@
-../../../schema/qapi/machine-target.json

--- a/qmp/schema/qapi/misc-arm.json
+++ b/qmp/schema/qapi/misc-arm.json
@@ -1,0 +1,1 @@
+../../../schema/qapi/misc-arm.json

--- a/qmp/schema/qapi/misc-i386.json
+++ b/qmp/schema/qapi/misc-i386.json
@@ -1,0 +1,1 @@
+../../../schema/qapi/misc-i386.json

--- a/qmp/schema/qapi/misc-target.json
+++ b/qmp/schema/qapi/misc-target.json
@@ -1,1 +1,0 @@
-../../../schema/qapi/misc-target.json


### PR DESCRIPTION
Branch for QEMU v11.0.1 release.

Changes on top of `main`:
- Update schema submodule to use `p-alik/qemu-qapi-filtered` `v11.0.1-filtered` branch
- Update `qmp/schema/qapi` links (add `acpi-hest`, `accelerator`, `machine-s390x`, `misc-arm`, `misc-i386`; remove `machine-target`, `misc-target`)
- codegen: improve error reporting for missing QAPI schema includes